### PR TITLE
CHORE: auto-assignment of labels from issue forms

### DIFF
--- a/.github/python-labeler-config.yml
+++ b/.github/python-labeler-config.yml
@@ -1,0 +1,59 @@
+mappings:
+  - label: "effort: 1"
+    options: ["1"]
+  - label: "effort: 2"
+    options: ["2"]
+  - label: "effort: 3"
+    options: ["3"]
+  - label: "effort: 5"
+    options: ["5"]
+  - label: "effort: 8"
+    options: ["8"]
+  - label: "effort: 13"
+    options: ["13"]
+  - label: "effort: 21"
+    options: ["21"]
+  - label: "priority: critical"
+    options: ["critical"]
+  - label: "priority: high"
+    options: ["high"]
+  - label: "priority: medium"
+    options: ["medium"]
+  - label: "priority: low"
+    options: ["low"]
+  - label: "work: chaotic"
+    options: ["chaotic"]
+  - label: "work: complex"
+    options: ["complex"]
+  - label: "work: complicated"
+    options: ["complicated"]
+  - label: "work: obvious"
+    options: ["obvious"]
+  - label: "app: backend - aggregator"
+    options: ["backend - aggregator"]
+  - label: "app: backend - attestion queue (sqs)"
+    options: ["backend - attestion queue (sqs)"]
+  - label: "app: backend - attestor"
+    options: ["backend - attestor"]
+  - label: "app: backend - cache (dynamodb)"
+    options: ["backend - cache (dynamodb)"]
+  - label: "app: backend - config (s3)"
+    options: ["backend - config (s3)"]
+  - label: "app: backend - onboarding"
+    options: ["backend - onboarding"]
+  - label: "app: backend - pypi"
+    options: ["backend - pypi"]
+  - label: "app: backend - triager"
+    options: ["backend - triager"]
+  - label: "app: frontend - landing"
+    options: ["frontend - landing"]
+  - label: "app: frontend - onboarding"
+    options: ["frontend - onboarding"]
+  - label: "app: frontend - widget"
+    options: ["frontend - widget"]
+  - label: "app: frontend - zk credentials"
+    options: ["frontend - zk credentials"]
+  - label: "app: frontend - admin"
+    options: ["frontend - admin"]
+  - label: "stream: frontend"
+    options: ["frontend - landing", "frontend - onboarding", "frontend - widget", "frontend - zk credentials", "frontend - admin"]

--- a/.github/workflows/python-labeler.yaml
+++ b/.github/workflows/python-labeler.yaml
@@ -1,0 +1,55 @@
+name: Issue labeler (Python)
+on:
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  label-issues-policy:
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      issues: write
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout this repo
+        id: checkout-generic
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CHECKOUT_TOKEN }}
+
+      - name: Checkout labels repository
+        id: checkout-labels
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CHECKOUT_TOKEN }}
+          repository: keyring-network/labels
+          path: labels-repo
+
+      - name: Setup Python
+        id: python-setup
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Dependencies
+        id: python-pip
+        run: pip install PyGithub pyyaml
+
+      - name: Apply labels
+        id: labels-apply
+        env:
+          GITHUB_TOKEN: ${{ secrets.LABELS_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PARSED_ISSUE: ${{ steps.issue-parser.outputs.jsonString }}
+          LABEL_MAPPING_FILE: .github/python-labeler-config.yml
+        run: |
+          python ${{ github.workspace }}/labels-repo/scripts/auto_labeller.py \
+            --token=$GITHUB_TOKEN \
+            --repo=$GITHUB_REPOSITORY \
+            --issue-number=$ISSUE_NUMBER \
+            --label-mapping-file=$LABEL_MAPPING_FILE


### PR DESCRIPTION
# Changes

Adds auto-labelling support to that now a github action should assign labels based on the issue form selections

**Quality**
- [x] I have performed a self-review of my code
- [ ] Doctests are present according to the style guide (below)

**Admin**
- [x] I have labelled this PR correctly
  - [x] App (if any)
  - [x] effort (required)
  - [x] work (required)
  - [x] stream (required)
  - [x] priority (required)
  - [x] type (required)
- [x] I have linked this PR to the correct Project
- [x] I have linked this PR to all relevant issues *(can only be done after creation)*

-------------------
# Style Guide - Please leave this in the PR

## Breaking Changes
If this PR introduces breaking changes please list apps that will be affected and the associated PRs to resolve these issues.

## Docstring / Function Style Guide

### Descriptors
Type hinted using python 3.8 `typing` module should be present throughout your code. Methods that return `self` should return the
class itself which c an be doin by importing
```python
from future import __annotations__
```
at the top of the mopdule.

### Documentation
Docstrings should be using Google's Napoleon docstring format with the following caveats:

* A short descriptive line at the top of the docstring explaining the high level utility of the function
* The following sections, only with the listed criteria
    * Args: No types in the parameters because the function is already type hinted.
    * Returns: No Type hinting as the descriptor has this
    * Examples: This should be a valid doctest that demonstrates the function working

#### Example
**Bad Example**
```python
def func(x):
    {result: x**2}
```
**Good Example**
```python
from typing import Dict

def func(x: int) -> Dict[str, int]:
    """
    Return ``x**2`` in a JSON result

    Args:
        x: integer value to square

    Example:
        >>> func(2)
        {'result': 4}

    Returns:
        A dictionary like ``{result: x**2}``
    """
    return {result: x**2}
```

In short functions like this it is fine to ignore the doctest and the returns, instead giving a simpler docstring in accordance with PEP8

**Good Example 2**
```python
from typing import Dict

def func(x: int) -> Dict[str, int]:
    """
    Return the square of ``x`` as a dict like ``{result: x**2}``
    """
    return {result: x**2}
```

### Future Alignment: Sphinx Support (optional)

*If you are familiar with Sphinx language it is highly recommended to use sphinx syntax in docstrings to align witth future documentation plans.*
